### PR TITLE
Splitting preflight and non-preflight health indicator interfaces

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/health/GetHealthActionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/health/GetHealthActionIT.java
@@ -83,7 +83,7 @@ public class GetHealthActionIT extends ESIntegTestCase {
 
     public static final class TestHealthPlugin extends Plugin implements HealthPlugin {
 
-        private final List<HealthIndicatorService> healthIndicatorServices = new ArrayList<>();
+        private final List<NonPreflightHealthIndicatorService> healthIndicatorServices = new ArrayList<>();
 
         @Override
         public List<Setting<?>> getSettings() {
@@ -113,7 +113,7 @@ public class GetHealthActionIT extends ESIntegTestCase {
         }
 
         @Override
-        public Collection<HealthIndicatorService> getHealthIndicatorServices() {
+        public Collection<NonPreflightHealthIndicatorService> getHealthIndicatorServices() {
             return healthIndicatorServices;
         }
     }
@@ -121,7 +121,7 @@ public class GetHealthActionIT extends ESIntegTestCase {
     /**
      * This indicator pulls its status from the statusSetting Setting.
      */
-    public static class TestHealthIndicatorService implements HealthIndicatorService {
+    public static class TestHealthIndicatorService implements NonPreflightHealthIndicatorService {
 
         private final ClusterService clusterService;
         private final String indicatorName;

--- a/server/src/internalClusterTest/java/org/elasticsearch/health/HealthServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/health/HealthServiceIT.java
@@ -106,7 +106,7 @@ public class HealthServiceIT extends ESIntegTestCase {
 
     public static final class TestHealthPlugin extends Plugin implements HealthPlugin {
 
-        private final List<HealthIndicatorService> healthIndicatorServices = new ArrayList<>();
+        private final List<NonPreflightHealthIndicatorService> healthIndicatorServices = new ArrayList<>();
 
         @Override
         public Collection<Object> createComponents(
@@ -129,12 +129,12 @@ public class HealthServiceIT extends ESIntegTestCase {
         }
 
         @Override
-        public Collection<HealthIndicatorService> getHealthIndicatorServices() {
+        public Collection<NonPreflightHealthIndicatorService> getHealthIndicatorServices() {
             return healthIndicatorServices;
         }
     }
 
-    public static final class TestHealthIndicatorService implements HealthIndicatorService {
+    public static final class TestHealthIndicatorService implements NonPreflightHealthIndicatorService {
         public static final String NAME = "test_indicator";
         public static final String SYMPTOM = "Symptom";
 

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/StableMasterHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/StableMasterHealthIndicatorService.java
@@ -13,10 +13,9 @@ import org.elasticsearch.health.Diagnosis;
 import org.elasticsearch.health.HealthIndicatorDetails;
 import org.elasticsearch.health.HealthIndicatorImpact;
 import org.elasticsearch.health.HealthIndicatorResult;
-import org.elasticsearch.health.HealthIndicatorService;
 import org.elasticsearch.health.HealthStatus;
 import org.elasticsearch.health.ImpactArea;
-import org.elasticsearch.health.node.HealthInfo;
+import org.elasticsearch.health.PreflightHealthIndicatorService;
 
 import java.util.Collection;
 import java.util.List;
@@ -34,7 +33,7 @@ import java.util.Map;
  * Since this indicator needs to be able to run when there is no master at all, it does not depend on the dedicated health node (which
  * requires the existence of a master).
  */
-public class StableMasterHealthIndicatorService implements HealthIndicatorService {
+public class StableMasterHealthIndicatorService implements PreflightHealthIndicatorService {
 
     public static final String NAME = "master_is_stable";
     public static final String GET_HELP_GUIDE = "https://ela.st/getting-help";
@@ -84,7 +83,7 @@ public class StableMasterHealthIndicatorService implements HealthIndicatorServic
     }
 
     @Override
-    public HealthIndicatorResult calculate(boolean explain, HealthInfo healthInfo) {
+    public HealthIndicatorResult calculate(boolean explain) {
         CoordinationDiagnosticsService.CoordinationDiagnosticsResult coordinationDiagnosticsResult = coordinationDiagnosticsService
             .diagnoseMasterStability(explain);
         return getHealthIndicatorResult(coordinationDiagnosticsResult, explain);

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityHealthIndicatorService.java
@@ -38,9 +38,9 @@ import org.elasticsearch.health.Diagnosis;
 import org.elasticsearch.health.HealthIndicatorDetails;
 import org.elasticsearch.health.HealthIndicatorImpact;
 import org.elasticsearch.health.HealthIndicatorResult;
-import org.elasticsearch.health.HealthIndicatorService;
 import org.elasticsearch.health.HealthStatus;
 import org.elasticsearch.health.ImpactArea;
+import org.elasticsearch.health.NonPreflightHealthIndicatorService;
 import org.elasticsearch.health.SimpleHealthIndicatorDetails;
 import org.elasticsearch.health.node.HealthInfo;
 import org.elasticsearch.snapshots.SnapshotShardSizeInfo;
@@ -84,7 +84,7 @@ import static org.elasticsearch.health.HealthStatus.YELLOW;
  * Each shard needs to be available and replicated in order to guarantee high availability and prevent data loses.
  * Shards allocated on nodes scheduled for restart (using nodes shutdown API) will not degrade this indicator health.
  */
-public class ShardsAvailabilityHealthIndicatorService implements HealthIndicatorService {
+public class ShardsAvailabilityHealthIndicatorService implements NonPreflightHealthIndicatorService {
 
     private static final Logger LOGGER = LogManager.getLogger(ShardsAvailabilityHealthIndicatorService.class);
 

--- a/server/src/main/java/org/elasticsearch/health/HealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/health/HealthIndicatorService.java
@@ -8,8 +8,6 @@
 
 package org.elasticsearch.health;
 
-import org.elasticsearch.health.node.HealthInfo;
-
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
@@ -21,8 +19,6 @@ import java.util.stream.Collectors;
 public interface HealthIndicatorService {
 
     String name();
-
-    HealthIndicatorResult calculate(boolean explain, HealthInfo healthInfo);
 
     /**
      * This method creates a HealthIndicatorResult with the given information. Note that it sorts the impacts by severity (the lower the

--- a/server/src/main/java/org/elasticsearch/health/NonPreflightHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/health/NonPreflightHealthIndicatorService.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.health;
+
+import org.elasticsearch.health.node.HealthInfo;
+
+public interface NonPreflightHealthIndicatorService extends HealthIndicatorService {
+    HealthIndicatorResult calculate(boolean explain, HealthInfo healthInfo);
+}

--- a/server/src/main/java/org/elasticsearch/health/PreflightHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/health/PreflightHealthIndicatorService.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.health;
+
+public interface PreflightHealthIndicatorService extends HealthIndicatorService {
+    HealthIndicatorResult calculate(boolean explain);
+}

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -102,8 +102,8 @@ import org.elasticsearch.gateway.GatewayModule;
 import org.elasticsearch.gateway.GatewayService;
 import org.elasticsearch.gateway.MetaStateService;
 import org.elasticsearch.gateway.PersistedClusterStateService;
-import org.elasticsearch.health.HealthIndicatorService;
 import org.elasticsearch.health.HealthService;
+import org.elasticsearch.health.PreflightHealthIndicatorService;
 import org.elasticsearch.health.metadata.HealthMetadataService;
 import org.elasticsearch.health.node.HealthInfoCache;
 import org.elasticsearch.health.node.LocalHealthMonitor;
@@ -1161,7 +1161,7 @@ public class Node implements Closeable {
         ClusterModule clusterModule,
         CoordinationDiagnosticsService coordinationDiagnosticsService
     ) {
-        List<HealthIndicatorService> preflightHealthIndicatorServices = Collections.singletonList(
+        List<PreflightHealthIndicatorService> preflightHealthIndicatorServices = Collections.singletonList(
             new StableMasterHealthIndicatorService(coordinationDiagnosticsService)
         );
         var serverHealthIndicatorServices = List.of(

--- a/server/src/main/java/org/elasticsearch/plugins/HealthPlugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/HealthPlugin.java
@@ -8,7 +8,7 @@
 
 package org.elasticsearch.plugins;
 
-import org.elasticsearch.health.HealthIndicatorService;
+import org.elasticsearch.health.NonPreflightHealthIndicatorService;
 
 import java.util.Collection;
 
@@ -17,5 +17,5 @@ import java.util.Collection;
  */
 public interface HealthPlugin {
 
-    Collection<HealthIndicatorService> getHealthIndicatorServices();
+    Collection<NonPreflightHealthIndicatorService> getHealthIndicatorServices();
 }

--- a/server/src/main/java/org/elasticsearch/snapshots/RepositoryIntegrityHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RepositoryIntegrityHealthIndicatorService.java
@@ -15,8 +15,8 @@ import org.elasticsearch.health.Diagnosis;
 import org.elasticsearch.health.HealthIndicatorDetails;
 import org.elasticsearch.health.HealthIndicatorImpact;
 import org.elasticsearch.health.HealthIndicatorResult;
-import org.elasticsearch.health.HealthIndicatorService;
 import org.elasticsearch.health.ImpactArea;
+import org.elasticsearch.health.NonPreflightHealthIndicatorService;
 import org.elasticsearch.health.SimpleHealthIndicatorDetails;
 import org.elasticsearch.health.node.HealthInfo;
 import org.elasticsearch.repositories.RepositoryData;
@@ -39,7 +39,7 @@ import static org.elasticsearch.health.HealthStatus.RED;
  *
  * Corrupted repository most likely need to be manually cleaned and a new snapshot needs to be created from scratch.
  */
-public class RepositoryIntegrityHealthIndicatorService implements HealthIndicatorService {
+public class RepositoryIntegrityHealthIndicatorService implements NonPreflightHealthIndicatorService {
 
     public static final String NAME = "repository_integrity";
 

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/StableMasterHealthIndicatorServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/StableMasterHealthIndicatorServiceTests.java
@@ -25,7 +25,6 @@ import org.elasticsearch.health.Diagnosis;
 import org.elasticsearch.health.HealthIndicatorDetails;
 import org.elasticsearch.health.HealthIndicatorResult;
 import org.elasticsearch.health.HealthStatus;
-import org.elasticsearch.health.node.HealthInfo;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.ToXContent;
@@ -242,7 +241,7 @@ public class StableMasterHealthIndicatorServiceTests extends AbstractCoordinator
 
         // Change 4:
         localMasterHistory.clusterChanged(new ClusterChangedEvent(TEST_SOURCE, node2MasterClusterState, node3MasterClusterState));
-        HealthIndicatorResult result = service.calculate(true, HealthInfo.EMPTY_HEALTH_INFO);
+        HealthIndicatorResult result = service.calculate(true);
         assertThat(result.status(), equalTo(HealthStatus.YELLOW));
         assertThat(result.symptom(), equalTo("The elected master node has changed 4 times in the last 30m"));
         assertThat(result.impacts().size(), equalTo(3));

--- a/server/src/test/java/org/elasticsearch/health/HealthIndicatorServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/health/HealthIndicatorServiceTests.java
@@ -52,8 +52,8 @@ public class HealthIndicatorServiceTests extends ESTestCase {
         assertEquals(expectedImpacts, outputImpacts);
     }
 
-    private HealthIndicatorService getTestHealthIndicatorService() {
-        return new HealthIndicatorService() {
+    private NonPreflightHealthIndicatorService getTestHealthIndicatorService() {
+        return new NonPreflightHealthIndicatorService() {
             @Override
             public String name() {
                 return null;

--- a/server/src/test/java/org/elasticsearch/plugins/PluginIntrospectorTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/PluginIntrospectorTests.java
@@ -20,7 +20,7 @@ import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
-import org.elasticsearch.health.HealthIndicatorService;
+import org.elasticsearch.health.NonPreflightHealthIndicatorService;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.analysis.TokenFilterFactory;
 import org.elasticsearch.index.engine.EngineFactory;
@@ -141,7 +141,7 @@ public class PluginIntrospectorTests extends ESTestCase {
             }
 
             @Override
-            public Collection<HealthIndicatorService> getHealthIndicatorServices() {
+            public Collection<NonPreflightHealthIndicatorService> getHealthIndicatorServices() {
                 return null;
             }
 
@@ -295,7 +295,7 @@ public class PluginIntrospectorTests extends ESTestCase {
             }
 
             @Override
-            public Collection<HealthIndicatorService> getHealthIndicatorServices() { // from Health
+            public Collection<NonPreflightHealthIndicatorService> getHealthIndicatorServices() { // from Health
                 return null;
             }
         }

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IlmHealthIndicatorService.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IlmHealthIndicatorService.java
@@ -12,8 +12,8 @@ import org.elasticsearch.health.Diagnosis;
 import org.elasticsearch.health.HealthIndicatorDetails;
 import org.elasticsearch.health.HealthIndicatorImpact;
 import org.elasticsearch.health.HealthIndicatorResult;
-import org.elasticsearch.health.HealthIndicatorService;
 import org.elasticsearch.health.ImpactArea;
+import org.elasticsearch.health.NonPreflightHealthIndicatorService;
 import org.elasticsearch.health.SimpleHealthIndicatorDetails;
 import org.elasticsearch.health.node.HealthInfo;
 import org.elasticsearch.xpack.core.ilm.IndexLifecycleMetadata;
@@ -34,7 +34,7 @@ import static org.elasticsearch.health.HealthStatus.YELLOW;
  *
  * ILM must be running to fix warning reported by this indicator.
  */
-public class IlmHealthIndicatorService implements HealthIndicatorService {
+public class IlmHealthIndicatorService implements NonPreflightHealthIndicatorService {
 
     public static final String NAME = "ilm";
 

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycle.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycle.java
@@ -27,7 +27,7 @@ import org.elasticsearch.common.settings.SettingsFilter;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
-import org.elasticsearch.health.HealthIndicatorService;
+import org.elasticsearch.health.NonPreflightHealthIndicatorService;
 import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.license.XPackLicenseState;
@@ -432,7 +432,7 @@ public class IndexLifecycle extends Plugin implements ActionPlugin, HealthPlugin
     }
 
     @Override
-    public Collection<HealthIndicatorService> getHealthIndicatorServices() {
+    public Collection<NonPreflightHealthIndicatorService> getHealthIndicatorServices() {
         return List.of(ilmHealthIndicatorService.get(), slmHealthIndicatorService.get());
     }
 

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SlmHealthIndicatorService.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SlmHealthIndicatorService.java
@@ -12,8 +12,8 @@ import org.elasticsearch.health.Diagnosis;
 import org.elasticsearch.health.HealthIndicatorDetails;
 import org.elasticsearch.health.HealthIndicatorImpact;
 import org.elasticsearch.health.HealthIndicatorResult;
-import org.elasticsearch.health.HealthIndicatorService;
 import org.elasticsearch.health.ImpactArea;
+import org.elasticsearch.health.NonPreflightHealthIndicatorService;
 import org.elasticsearch.health.SimpleHealthIndicatorDetails;
 import org.elasticsearch.health.node.HealthInfo;
 import org.elasticsearch.xpack.core.ilm.OperationMode;
@@ -40,7 +40,7 @@ import static org.elasticsearch.xpack.core.ilm.LifecycleSettings.SLM_HEALTH_FAIL
  *
  * SLM must be running to fix warning reported by this indicator.
  */
-public class SlmHealthIndicatorService implements HealthIndicatorService {
+public class SlmHealthIndicatorService implements NonPreflightHealthIndicatorService {
 
     public static final String NAME = "slm";
 


### PR DESCRIPTION
Splitting `HealthIndicatorService` into `PreflightHealthIndicatorService` and `NonPreflightHealthIndicatorService`.