### PR TITLE
Disk indicator review

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/StableMasterHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/StableMasterHealthIndicatorService.java
@@ -72,7 +72,7 @@ public class StableMasterHealthIndicatorService implements HealthIndicatorServic
     /**
      * This is the list of the impacts to be reported when the master node is determined to be unstable.
      */
-    public static final List<HealthIndicatorImpact> UNSTABLE_MASTER_IMPACTS = List.of(
+    private static final List<HealthIndicatorImpact> UNSTABLE_MASTER_IMPACTS = List.of(
         new HealthIndicatorImpact(1, UNSTABLE_MASTER_INGEST_IMPACT, List.of(ImpactArea.INGEST)),
         new HealthIndicatorImpact(1, UNSTABLE_MASTER_DEPLOYMENT_MANAGEMENT_IMPACT, List.of(ImpactArea.DEPLOYMENT_MANAGEMENT)),
         new HealthIndicatorImpact(3, UNSTABLE_MASTER_BACKUP_IMPACT, List.of(ImpactArea.BACKUP))


### PR DESCRIPTION
As requested, I am applying the review requests in a PR to speed up the process. Here I am listing them with an explanation in regards to why I thought this was a good idea.
- **Use only one cluster state in a single calculation.** I think this will help with the stability of the calculation and the debugging if issues arise. Furthermore, it makes explicit that in order to de-reference the roles and names we need the cluster state.
